### PR TITLE
Modify indicator-based rotation.

### DIFF
--- a/Assets/Scripts/Robot/RobotConfig.cs
+++ b/Assets/Scripts/Robot/RobotConfig.cs
@@ -101,7 +101,6 @@ namespace TeleopReachy
         {
             Debug.Log("[Robot config]: SetMobilePlatform");
             has_mobile_platform = true;
-
             event_OnConfigChanged.Invoke();
         }
 

--- a/Assets/Scripts/Robot/RobotStatus.cs
+++ b/Assets/Scripts/Robot/RobotStatus.cs
@@ -19,7 +19,7 @@ namespace TeleopReachy
 
         private bool isMobilityInBreakMode;
 
-        private bool isMobilityOn; // true if operator want to have control of the mobile base, false otherwise
+        private bool isMobilityOn = true; // true if operator want to have control of the mobile base, false otherwise
 
         private bool isLeftArmOn = true; // true if operator want to have control of the left arm, false otherwise
 

--- a/Assets/Scripts/UI/RobotMobilityUIManager.cs
+++ b/Assets/Scripts/UI/RobotMobilityUIManager.cs
@@ -20,7 +20,7 @@ namespace TeleopReachy
         private Transform userTracker;
 
         private ConnectionStatus connectionStatus;
-        
+
 
         private Vector2 directionLeft;
         private Vector2 directionRight;
@@ -30,7 +30,6 @@ namespace TeleopReachy
 
         private bool ShowMobilityUIListenerSet = false;
         private bool HideMobilityUIListenerSet = false;
-        private bool SwitchMobilityOnListenerSet = false;
 
         [SerializeField]
         private Transform indicator;
@@ -73,22 +72,18 @@ namespace TeleopReachy
 
             UpdateMobilityUI(robotConfig.HasMobilePlatform());
 
-            if (SwitchMobilityOnListenerSet == false)
-            {
+            if (robotConfig.HasMobilePlatform())
                 robotStatus.event_OnSwitchMobilityOn.AddListener(UpdateMobilityUI);
-                SwitchMobilityOnListenerSet = true;
-            }
-
         }
 
         void UpdateMobilityUI(bool on)
         {
-            if (on == false)
+            if (!on)
             {
                 ShowMobilityUIListenerSet = false;
                 HideMobilityUIListenerSet = false;
-                robotStatus.event_OnStartTeleoperation.RemoveListener(ShowMobilityUI);   
-                robotStatus.event_OnStopTeleoperation.RemoveListener(HideMobilityUI);   
+                robotStatus.event_OnStartTeleoperation.RemoveListener(ShowMobilityUI);
+                robotStatus.event_OnStopTeleoperation.RemoveListener(HideMobilityUI);
             }
             else
             {

--- a/Assets/Scripts/UI/RobotMobilityUIManager.cs
+++ b/Assets/Scripts/UI/RobotMobilityUIManager.cs
@@ -131,7 +131,7 @@ namespace TeleopReachy
                 directionLeft = userMobilityInput.GetMobileBaseDirection();
                 directionRight = userMobilityInput.GetAngleDirection();
 
-                float rotation = Mathf.Atan2(directionRight[1], directionRight[0]);
+                float rotation = -directionRight[0];
 
                 arrowRightRotationCommand.gameObject.SetActive(rotation < 0);
                 arrowLeftRotationCommand.gameObject.SetActive(rotation > 0);


### PR DESCRIPTION
Rotation used for the indicator should be the same as the rotation used in mobilityCommands.SendMobileBaseDirection.